### PR TITLE
Fixes DS-325: Typo in tigcache() existence check

### DIFF
--- a/bootstrap/tig_functions.php
+++ b/bootstrap/tig_functions.php
@@ -8,7 +8,7 @@
  * in other environments.
  */
 
-if (!function_exists('tigcache)'))
+if (!function_exists('tigcache'))
 {
   /**
    * Mock cached query result function. If $assume_single is truthy, return


### PR DESCRIPTION
Oy, this typo was causing the API in prod to try to redeclare tigcache().
