### PR TITLE
Adds flSHA user field for incoming users.

### DIFF
--- a/app/helpers/Tig/UserHelper.php
+++ b/app/helpers/Tig/UserHelper.php
@@ -18,8 +18,19 @@ class UserHelper {
    * @param $raw
    * @return string
    */
-  public static function makePassword($raw) {
-    return hash('sha256', $raw);
+  public static function makePassword($raw_password) {
+    // SHA256 for new passwords.
+    return hash('sha256', $raw_password);
+  }
+
+  /**
+   * Sets hash method for the user password.
+   *
+   * @param $data
+   * @return string
+   */
+  public static function setPasswordHashMethod(&$data) {
+    $data['flSHA'] = 1;
   }
 
   /**

--- a/app/lib/Tig/Storage/User/EloquentUserRepository.php
+++ b/app/lib/Tig/Storage/User/EloquentUserRepository.php
@@ -110,6 +110,7 @@ class EloquentUserRepository implements UserRepository {
     {
       // SHA256 for new passwords.
       $data['password'] = UserHelper::makePassword($data['password']);
+      UserHelper::setPasswordHashMethod($data);
     }
 
     // Map Laravel-happy column names to their TiG DB equivalents.


### PR DESCRIPTION
#### What's this PR do?
- Sets `flSHA` user field for incoming users
#### Any background context you want to provide?

This will work in case the `flSHA` exists in the `tigapi.Users` table:
![screen shot 2014-11-18 at 12 35 56 am](https://cloud.githubusercontent.com/assets/672669/5079195/e13feb34-6eba-11e4-85b3-0c6879b668ce.png)

Consistency with current Drupal implementation verified by integration tests:
![image](https://cloud.githubusercontent.com/assets/672669/5079213/ffe0d530-6eba-11e4-9706-a156d6ef15f6.png)
#### What are the relevant tickets?

Closes #8.

CC @mshmsh5000 @mfurdyk 
