### PR TITLE
Don't use user email and phone in username generation.

### DIFF
--- a/app/helpers/Tig/UserHelper.php
+++ b/app/helpers/Tig/UserHelper.php
@@ -7,6 +7,7 @@
 namespace Tig;
 
 use Illuminate\Support\Facades\DB as DB;
+use Illuminate\Support\Str as Str;
 
 class UserHelper {
 
@@ -34,24 +35,14 @@ class UserHelper {
   }
 
   /**
-   * Try to use various properties to make a reasonable username for TiG.
+   * Return generated username based on first name and current time stamp
+   * to avoid collisions.
    *
    * @param $data
    * @return string
    */
   public static function makeUsername($data) {
-
-    if (!empty($data['mobile']))
-    {
-      return self::$USERNAME_PREFIX . preg_replace('/[^0-9]*/', '', $data['mobile']);
-    }
-
-    if (!empty($data['email']))
-    {
-      return self::$USERNAME_PREFIX . preg_replace('/[^a-z0-9A-Z]*/', '', $data['email']);
-    }
-
-    return substr(hash('sha256', time()), 16);
+    return Str::lower($data['firstName']) . '-' . time();
   }
 
   /**

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -92,6 +92,7 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
   private $rules = array(
     'Name'     => 'required',
     'Email'    => 'required|email|unique:Users,Email',
+    'Username' => 'required|unique:Users,Username',
     'Password' => 'required',
     'DOB'      => 'required|date',
   );
@@ -124,7 +125,8 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
     if ($this->exists) {
       // @see http://laravel.com/docs/4.2/validation#rule-unique
       // unique:table,column,except,idColumn
-      $rules['Email'] .= ',' . $this->UserID . ',UserID';
+      $rules['Email']    .= ',' . $this->UserID . ',UserID';
+      $rules['Username'] .= ',' . $this->UserID . ',UserID';
     }
     $validator = Validator::make($this->attributes, $rules);
 


### PR DESCRIPTION
#### What's this PR do?
- Removes user email address and phone number from `makeUsername()` helper in order to protect sensetive user data from being exposed to the public through profile URL
#### Testing

Changes consistent with DS Canada:
![image](https://cloud.githubusercontent.com/assets/672669/5928318/4b30e2d6-a648-11e4-8611-d7b2809c65cc.png)

CC @mshmsh5000 @mfurdyk 
